### PR TITLE
Create `Layout.astro` in `index.astro` with Typography test

### DIFF
--- a/src/components/atoms/Head.astro
+++ b/src/components/atoms/Head.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  faviconUrl: string
+  title: string
+}
+
+const { faviconUrl, title } = Astro.props
+---
+
+<meta charset="utf-8" />
+<link
+  rel="icon"
+  type="image/svg+xml"
+  href={faviconUrl}
+/>
+<meta
+  name="viewport"
+  content="width=device-width"
+/>
+<meta
+  name="description"
+  content="App de mensajería en línea con amigos o desconocidos"
+/>
+<meta
+  name="author"
+  content="ConanGH-S, KrlosPK, ST-Benji"
+/>
+<meta
+  name="keywords"
+  content="Real time chat, mensajería, messages, real time"
+/>
+<meta
+  name="generator"
+  content={Astro.generator}
+/>
+<title>{title}</title>

--- a/src/components/atoms/Typography.astro
+++ b/src/components/atoms/Typography.astro
@@ -3,8 +3,8 @@ import type { HTMLTag, Polymorphic } from 'astro/types'
 
 type Props<Tag extends HTMLTag> = Polymorphic<{
   as: Tag
-  variant: TVariantClasses
-  color: TColorsClasses
+  variant: keyof typeof variantClasses
+  color: keyof typeof colorClasses
 }>
 
 const { as: Tag, variant, color, class: className, ...props } = Astro.props
@@ -13,16 +13,12 @@ const variantClasses: Record<string, string> = {
   h1: 'text-3xl text-bold uppercase lg:text-4xl'
 } as const
 
-type TVariantClasses = keyof typeof variantClasses
-
 const colorClasses = {
   white: 'text-white',
   black: 'text-black',
   primary: 'text-accent',
   neutral: 'text-neutral-300'
 }
-
-type TColorsClasses = keyof typeof colorClasses
 
 const classes = [
   variantClasses[variant as keyof typeof variantClasses],

--- a/src/components/atoms/Typography.astro
+++ b/src/components/atoms/Typography.astro
@@ -3,13 +3,15 @@ import type { HTMLTag, Polymorphic } from 'astro/types'
 
 type Props<Tag extends HTMLTag> = Polymorphic<{
   as: Tag
-  variant: keyof typeof variantClasses
-  color: keyof typeof colorClasses
+  variant: TVariantClasses
+  color: TColorClasses
 }>
 
 const { as: Tag, variant, color, class: className, ...props } = Astro.props
 
-const variantClasses: Record<string, string> = {
+type TVariantClasses = keyof typeof variantClasses
+
+const variantClasses = {
   h1: 'text-3xl text-bold uppercase lg:text-4xl'
 } as const
 
@@ -18,7 +20,9 @@ const colorClasses = {
   black: 'text-black',
   primary: 'text-accent',
   neutral: 'text-neutral-300'
-}
+} as const
+
+type TColorClasses = keyof typeof colorClasses
 
 const classes = [
   variantClasses[variant as keyof typeof variantClasses],

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,9 @@
 ---
+type Languages = 'es' | 'en'
+
 interface Props {
   title: string
-  language: string
+  language: Languages
   faviconUrl: string
 }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,32 @@
+---
+interface Props {
+  title: string
+  language: string
+  faviconUrl: string
+}
+
+const { title, language, faviconUrl } = Astro.props
+---
+
+<html lang={language}>
+  <head>
+    <meta charset="utf-8" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href={faviconUrl}
+    />
+    <meta
+      name="viewport"
+      content="width=device-width"
+    />
+    <meta
+      name="generator"
+      content={Astro.generator}
+    />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import Typography from '@/components/atoms/Typography.astro'
 import Layout from '@/layouts/Layout.astro'
 ---
 
@@ -7,5 +8,10 @@ import Layout from '@/layouts/Layout.astro'
   faviconUrl="/favicon.svg"
   language="es"
 >
-  <h1>Hola</h1>
+  <Typography
+    color="black"
+    variant="h1"
+    as="h1"
+    >AlgoraCt</Typography
+  >
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,11 @@
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="/favicon.svg"
-    />
-    <meta
-      name="viewport"
-      content="width=device-width"
-    />
-    <meta
-      name="generator"
-      content={Astro.generator}
-    />
-    <title>Algora-ct</title>
-  </head>
-  <body>
-    <h1>Astro</h1>
-  </body>
-</html>
+---
+import Layout from '@/layouts/Layout.astro'
+---
+
+<Layout
+  title="Algora-ct"
+  faviconUrl="/favicon.svg"
+  language="es"
+>
+  <h1>Hola</h1>
+</Layout>


### PR DESCRIPTION
- Se ha añadido el island de Layout para la parte del head del html; este ha sido agregado para el index.html.
- Se ha corregido un error de tipado dentro del `Typography.astro`, haciendo que dentro de las variantes y as, no se haga el respectivo autocompletado de tipos debido a que TS no reconocia el objeto como readonly
## Imágenes
![image](https://github.com/KrlosPK/algora-ct/assets/80909795/40cceae6-20fd-44b2-bf02-df99502125fe)
> Con el const y sin un Record TS puede diferir que estas keys no van a cambiar