### PR TITLE
Colores del proyecto añadidos

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,5 +21,13 @@ const { title, language, faviconUrl } = Astro.props
   </head>
   <body>
     <slot />
+    <style is:global>
+      :root {
+        --primary-color: #00b3cd;
+        --secondary-color: #004c6f;
+        --base-color: #fff;
+        --foreground-color: #191919;
+      }
+    </style>
   </body>
 </html>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,7 +2,14 @@
 export default {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
-		extend: {},
+		extend: {
+			colors: {
+				primary: 'var(--primary-color)',
+				secondary: 'var(--secondary-color)',
+				base: 'var(--base-color)',
+				foreground: 'var(--foreground-color)'
+			}
+		},
 	},
 	plugins: [],
 }


### PR DESCRIPTION
## Descripción

Se han añadido los colores que se usarán para el proyecto base

## Problema solucionado

Se han agregado las variables a tailwind para su uso

## Cambios propuestos

- Colores base del proyecto

## Capturas de pantalla (si corresponde)

![image](https://github.com/KrlosPK/algora-ct/assets/80909795/033844b4-0a0f-4731-8bc9-c5f2c54c42c1)

## Comprobación de cambios

- [ ✅ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar
- [ ✅ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ✅ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ✅ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Se pueden usar los colores en cualquier parte del proyecto con css o tailwind