### PR TITLE
Fix - a tailwind extend class for colors errors with text-base class

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,7 +6,7 @@ export default {
 			colors: {
 				primary: 'var(--primary-color)',
 				secondary: 'var(--secondary-color)',
-				base: 'var(--base-color)',
+				'base-primary': 'var(--base-color)',
 				foreground: 'var(--foreground-color)'
 			}
 		},


### PR DESCRIPTION
## Descripción

Se arregló la clase de base para los colores debido a que chocaba con la clase `text-base` y generaba incompatibilidad

## Problema solucionado

Debido a que chocaba, el texto realmente no se ponía del color que decía la variable, si no, blanco

## Cambios propuestos

- Cambiar el nombre de 'base' a 'base-primary'

## Comprobación de cambios

- [ ✅ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar
- [ ✅ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ✅ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ✅ ] He actualizado la documentación, si corresponde.

## Impacto potencial

No genera errores de compatibilidad

