### PR TITLE
Se agregan nuevos estilos para el link normal y nuevo tipo

### DIFF
--- a/src/components/organism/Navbar.astro
+++ b/src/components/organism/Navbar.astro
@@ -1,10 +1,12 @@
 ---
+import type { Code } from 'astro:components'
 import Action from '../atoms/Action.astro'
 import Typography from '../atoms/Typography.astro'
 
 export interface TNavLinks {
   name: string
   link: string
+  buttonStyle?: boolean
 }
 
 interface Props {
@@ -12,21 +14,26 @@ interface Props {
 }
 
 const { navLinks } = Astro.props
+
+const userButtonStyles =
+  'text-black font-medium border border-gray-300 py-2 px-2 rounded-3xl hover:text-primary hover:border-primary transition'
 ---
 
 <nav>
-  <ul class="hidden gap-3 sm:flex">
+  <ul class="hidden gap-4 sm:flex">
     {
-      navLinks.map(({ link, name }) => (
-        <li>
+      navLinks.map(({ link, name, buttonStyle }) => (
+        <li class="flex h-12 items-center">
           <Typography
             as="span"
-            color="light"
+            color="ultra-light"
             variant="base-normal"
+            class="transition hover:text-primary hover:brightness-75"
           >
             <Action
               as="a"
               href={link}
+              class:list={[buttonStyle === true && userButtonStyles]}
             >
               {name}
             </Action>


### PR DESCRIPTION
## Descripción

Se han agregado nuevos estilos con hover para los links. Además se ha agregado el objeto `ButtonStyle` es cual al ser true, se genera los estilos tipo button para el anchor

## Cambios propuestos

- Nueva opción no requerida para el tipo TNavLinks
- Nuevos estilos para los clásicos links con hover

## Capturas de pantalla (si corresponde)

### Antes
![image](https://github.com/KrlosPK/algora-ct/assets/80909795/78674629-a708-442f-9242-c5a2c75b25a6)

### Después
![image](https://github.com/KrlosPK/algora-ct/assets/80909795/3279dd49-1772-4076-8dfa-972945ebcc53)

## Comprobación de cambios

- [ ✅ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar
- [ ✅ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ✅ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ✅ ] He actualizado la documentación, si corresponde.

## Contexto adicional

El nuevo estilo tipo button no está siendo utilizado, debes agregar la llave buttonStyle con valor true para que este sea efectivo

